### PR TITLE
Add transaction aware JsonMapping for Parent Child

### DIFF
--- a/docs/parent_child_json.md
+++ b/docs/parent_child_json.md
@@ -1,0 +1,67 @@
+## Parent Child Extension to Json File Mapping Definition
+Parent child mapping is a work in progress. The theory behind it is that you can configure neo4j to sync parent child
+relationships to elasticsearch. Parent child relationships are based on edges. So as edges are updated new parent child
+relationships are created/updated.
+
+
+Mapping syntax and instructions can be found in the json-mapper readme. This pull iteration adds a third option to the
+config: parent_child_rels. This option is a dictionary of edge types. Each edge type can have one "parent" object. This
+object must be one of the nodes defined in node_mappings. The child node is defined under the "node" option. The options
+are identical to the node_mapping options. The related_by option is a  cypher query without the end nodes that connects the parent and child
+nodes. so if (Person)-[Acted_In]-(Movie) include -[Acted_In]- and not (Person) - the parent node- and - movie - the child node.
+Write the path with the parent node first and the child node at the end.
+
+NOTE: for now type of the child node must be the same as the label or neo4j will not be able to find the correct path to sync
+parent child.
+// TODO: clarify related_by a tiny bit
+
+Example mapping:
+```
+{
+  "defaults": {
+    "key_property": "uuid",
+    "nodes_index": "neo4j-index-node",
+    "relationships_index": "default-index-relationship",
+    "include_remaining_properties": true
+  },
+  "node_mappings": [
+    {
+      "condition": "hasLabel('Person')",
+      "type": "Person",
+      "properties": {
+        "search_string": "getProperty('firstName') + ' ' + getProperty('lastName')"
+      }
+    },
+    {
+      "condition": "hasLabel('Movie')",
+      "type": "Movie_Ind"
+    }
+  ],
+  "parent_child_rels": {
+      "ACTED_IN": {
+        "node": {
+          "condition": "hasLabel('Movie')",
+          "type": "Movie"
+        },
+        "parent": "Person",
+        "related_by": "-[ACTED_IN]-"
+      }
+  }
+}
+```
+
+
+
+
+Things to note
+* Elasticsearch index has to be pre-configured manually before neo4j run (to tell es that there is a parent child relationship)
+* The node "type" has to be the same as the neo4j label - in the future we will add a specific neo4j label option
+* Edge values are not stored in parent child relationships
+* You cannot have more than one type between children nodes and regular nodes
+
+* Code needs to be cleaned up.
+
+
+Things I want to do:
+Integrate with jsonvalidator to check against nodes.
+

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <!-- Add jar packageing (idk why its not there)-->
+    <!--<packaging>jar</packaging>-->
+
     <parent>
         <groupId>com.graphaware.neo4j</groupId>
         <artifactId>module-parent</artifactId>

--- a/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchModule.java
@@ -22,6 +22,7 @@ import com.graphaware.common.representation.DetachedNode;
 import com.graphaware.common.representation.DetachedRelationship;
 import com.graphaware.module.es.mapping.expression.NodeExpressions;
 import com.graphaware.module.es.mapping.expression.RelationshipExpressions;
+import com.graphaware.module.es.mapping.TransactionAwareMapping;
 import com.graphaware.runtime.config.TxDrivenModuleConfiguration;
 import com.graphaware.runtime.metadata.TxDrivenModuleMetadata;
 import com.graphaware.runtime.module.thirdparty.DefaultThirdPartyIntegrationModule;
@@ -83,6 +84,9 @@ public class ElasticSearchModule extends DefaultThirdPartyIntegrationModule {
     @Override
     public void start(GraphDatabaseService database) {
         super.start(database);
+        if (this.writer.getMapping() instanceof TransactionAwareMapping) {
+            ((TransactionAwareMapping) this.writer.getMapping()).setGraphDatabaseService(database);
+        }
 
         //Must be after start - else the ES connection is not initialised.
         if (reindex) {

--- a/src/main/java/com/graphaware/module/es/ElasticSearchModuleBootstrapper.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchModuleBootstrapper.java
@@ -17,6 +17,7 @@ package com.graphaware.module.es;
 import com.graphaware.common.log.LoggerFactory;
 import com.graphaware.module.es.mapping.DefaultMapping;
 import com.graphaware.module.es.mapping.Mapping;
+import com.graphaware.module.es.mapping.TransactionAwareMapping;
 import com.graphaware.module.es.util.ServiceLoader;
 import com.graphaware.runtime.module.BaseRuntimeModuleBootstrapper;
 import com.graphaware.runtime.module.RuntimeModule;
@@ -99,6 +100,9 @@ public class ElasticSearchModuleBootstrapper extends BaseRuntimeModuleBootstrapp
 
         String mappingClass = configExists(config, MAPPING) ? config.get(MAPPING) : "com.graphaware.module.es.mapping.DefaultMapping";
         Mapping mapping = ServiceLoader.loadMapping(mappingClass);
+        if (mapping instanceof TransactionAwareMapping) {
+            ((TransactionAwareMapping) mapping).setGraphDatabaseService(database);
+        }
         configuration = configuration.withMapping(mapping, config);
         LOG.info("Elasticsearch mapping configured with %s", mapping.getClass());
 

--- a/src/main/java/com/graphaware/module/es/ElasticSearchModuleBootstrapper.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchModuleBootstrapper.java
@@ -17,7 +17,6 @@ package com.graphaware.module.es;
 import com.graphaware.common.log.LoggerFactory;
 import com.graphaware.module.es.mapping.DefaultMapping;
 import com.graphaware.module.es.mapping.Mapping;
-import com.graphaware.module.es.mapping.TransactionAwareMapping;
 import com.graphaware.module.es.util.ServiceLoader;
 import com.graphaware.runtime.module.BaseRuntimeModuleBootstrapper;
 import com.graphaware.runtime.module.RuntimeModule;
@@ -100,9 +99,6 @@ public class ElasticSearchModuleBootstrapper extends BaseRuntimeModuleBootstrapp
 
         String mappingClass = configExists(config, MAPPING) ? config.get(MAPPING) : "com.graphaware.module.es.mapping.DefaultMapping";
         Mapping mapping = ServiceLoader.loadMapping(mappingClass);
-        if (mapping instanceof TransactionAwareMapping) {
-            ((TransactionAwareMapping) mapping).setGraphDatabaseService(database);
-        }
         configuration = configuration.withMapping(mapping, config);
         LOG.info("Elasticsearch mapping configured with %s", mapping.getClass());
 

--- a/src/main/java/com/graphaware/module/es/ElasticSearchWriter.java
+++ b/src/main/java/com/graphaware/module/es/ElasticSearchWriter.java
@@ -160,4 +160,9 @@ public class ElasticSearchWriter extends BaseThirdPartyWriter {
             }
         }
     }
+
+    public Mapping getMapping()
+    {
+        return mapping;
+    }
 }

--- a/src/main/java/com/graphaware/module/es/mapping/JsonFileMapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/JsonFileMapping.java
@@ -22,6 +22,7 @@ import com.graphaware.module.es.mapping.expression.RelationshipExpressions;
 import io.searchbox.action.BulkableAction;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.logging.Log;
 import org.springframework.core.io.ClassPathResource;
@@ -30,7 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
-public class JsonFileMapping implements Mapping {
+public class JsonFileMapping implements Mapping, TransactionAwareMapping {
 
     private static final Log LOG = LoggerFactory.getLogger(JsonFileMapping.class);
 
@@ -38,6 +39,8 @@ public class JsonFileMapping implements Mapping {
     private static final String FILE_PATH_KEY = "file";
 
     private DocumentMappingRepresentation mappingRepresentation;
+
+    private GraphDatabaseService database;
 
     protected String keyProperty;
 
@@ -101,5 +104,10 @@ public class JsonFileMapping implements Mapping {
     @Override
     public boolean bypassInclusionPolicies() {
         return true;
+    }
+
+    @Override
+    public void setGraphDatabaseService(GraphDatabaseService database) {
+        this.database = database;
     }
 }

--- a/src/main/java/com/graphaware/module/es/mapping/JsonFileMapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/JsonFileMapping.java
@@ -70,12 +70,12 @@ public class JsonFileMapping implements Mapping, TransactionAwareMapping {
     }
 
     public List<BulkableAction<? extends JestResult>> updateRelationship(RelationshipExpressions before, RelationshipExpressions after) {
-        return mappingRepresentation.updateRelationshipAndRemoveOldIndices(before, after);
+        return mappingRepresentation.createOrUpdateRelationship(after);
     }
 
     @Override
     public List<BulkableAction<? extends JestResult>> updateNode(NodeExpressions before, NodeExpressions after) {
-        return mappingRepresentation.updateNodeAndRemoveOldIndices(before, after);
+        return mappingRepresentation.createOrUpdateNode(after);
     }
 
     public List<BulkableAction<? extends JestResult>> deleteNode(NodeExpressions node) {
@@ -109,5 +109,6 @@ public class JsonFileMapping implements Mapping, TransactionAwareMapping {
     @Override
     public void setGraphDatabaseService(GraphDatabaseService database) {
         this.database = database;
+        mappingRepresentation.setGraphDatabaseService(database);
     }
 }

--- a/src/main/java/com/graphaware/module/es/mapping/MimirMapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/MimirMapping.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2013-2016 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.graphaware.module.es.mapping;
+
+import com.esotericsoftware.kryo.serializers.FieldSerializer;
+import com.graphaware.common.log.LoggerFactory;
+import com.graphaware.module.es.mapping.expression.NodeExpressions;
+import com.graphaware.module.es.mapping.expression.RelationshipExpressions;
+import io.searchbox.action.BulkableAction;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Delete;
+import io.searchbox.core.Index;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.logging.Log;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Iterator;
+
+/**
+ * This mapping indexes all documents in the same ElasticSearch index.
+ *
+ * The node's neo4j labels are stored are ElasticSearch "type".
+ * If a node has multiple labels, it is stored multiple times, once for each label.
+ *
+ * Relationships are not indexed.
+ */
+public class MimirMapping extends BaseMapping implements Mapping, TransactionAwareMapping {
+
+    private static final Log LOG = LoggerFactory.getLogger(MimirMapping.class);
+
+    // TODO: better message + make sure this doesn't break things
+    @FieldSerializer.Optional ("null")
+    private GraphDatabaseService database;
+
+    public void setGraphDatabaseService(GraphDatabaseService database) {
+        this.database = database;
+    }
+
+    public MimirMapping() {
+
+    }
+
+    @Override
+    public List<BulkableAction<? extends JestResult>> deleteNode(NodeExpressions node) {
+        String id = getKey(node);
+        List<BulkableAction<? extends JestResult>> actions = new ArrayList<>();
+
+        for (String label : node.getLabels()) {
+            actions.add(new Delete.Builder(id).index(getIndexFor(Node.class)).type(label).build());
+        }
+
+        return actions;
+    }
+
+    public static MimirMapping newInstance() {
+        return new MimirMapping();
+    }
+
+    @Override
+    public List<BulkableAction<? extends JestResult>> updateNode(NodeExpressions before, NodeExpressions after) {
+        return createOrUpdateNode(after);
+    }
+
+    @Override
+    public List<BulkableAction<? extends JestResult>> createNode(NodeExpressions node) {
+        return createOrUpdateNode(node);
+    }
+
+    protected List<BulkableAction<? extends JestResult>> createOrUpdateNode(NodeExpressions node) {
+        // This theoretically runs
+        // TODO: v v v v v
+        // Constraints:
+        //     * Does not take relationships into account - so if relationships are modified, or given values surrounding nodes won't
+        //          be updated
+        //     * Parent/Child index must be configured by hand (for now)
+        //     * Would need to find if the elasticsearch index is pre-configured (I think it is) - when would a reindex be implemented
+
+        String id = getKey(node);
+
+        // Build node id param list
+        Map<String, Object> params = new HashMap<>();
+        params.put("id", id);
+
+        // Plan (write a version of the code that hardcodes everything
+        // Plan ii Make everything configurable from file (or at least config) -- might have to modify json
+
+
+        Map<String, Object> source = map(node);
+        List<BulkableAction<? extends JestResult>> actions = new ArrayList<>();
+
+        //Dictionary mapping nodes to their parents using a cypher path
+        Map<String, String> tempNodeMapping = new HashMap<String, String>();
+        // return the uuid for processing by parent
+        // TODO: how would finding parents on multiple types of relationships work? - We probably want to do something else
+        // this.getKeyProperty() - index will get the property the key has been indexed with for searching
+        tempNodeMapping.put("Movie", "MATCH (n:Person)-[]-(x:Movie) where x." + this.getKeyProperty() + "  = {id} return n.uuid");
+
+        // For every label add the identical set of actions
+        for (String label : node.getLabels()) {
+
+            // Experiment here: if the label is person -> treat it as a normal node
+            // if the label is anything else find the parent (ie a person)
+            // Each label needs a mapping to the Person...
+
+            // Parent Nodes
+            if (label.equals("Person")) {
+                // Index how you normally would
+                actions.add(new Index.Builder(source).index(getIndexFor(Node.class)).type(label).id(id).build());
+            } else if (tempNodeMapping.containsKey(label)) {
+                // Get parent id's and iterate through
+
+                // Tentative plan - use cypher to find parents (easier than writing traversal)
+                Result results = this.database.execute(tempNodeMapping.get(label), params);
+
+                Iterator<String> parent_ids = results.columnAs("uuid");
+
+                // Loop through and get parent ids
+                while (parent_ids.hasNext()) {
+                    String ParentUUID = parent_ids.next();
+                    actions.add(new Index.Builder(source).index(getIndexFor(Node.class)).type(label).id(id).type("child").setParameter("parent", ParentUUID).build());
+                }
+
+            } else {
+                // Give up and just index how you normally would
+                actions.add(new Index.Builder(source).index(getIndexFor(Node.class)).type(label).id(id).build());
+            }
+//            actions.add(new Index.Builder(source).index(getIndexFor(Node.class)).type(label).id(id).build());
+        }
+
+        return actions;
+    }
+
+    @Override
+    public List<BulkableAction<? extends JestResult>> createRelationship(RelationshipExpressions relationship) {
+        return createOrUpdateRelationship(relationship);
+    }
+
+    @Override
+    public List<BulkableAction<? extends JestResult>> updateRelationship(RelationshipExpressions before, RelationshipExpressions after) {
+        return createOrUpdateRelationship(after);
+    }
+
+    @Override
+    public List<BulkableAction<? extends JestResult>> deleteRelationship(RelationshipExpressions r) {
+        return Collections.singletonList(
+                new Delete.Builder(getKey(r)).index(getIndexFor(Relationship.class)).type(r.getType()).build()
+        );
+    }
+
+    protected List<BulkableAction<? extends JestResult>> createOrUpdateRelationship(RelationshipExpressions r) {
+        return Collections.singletonList(
+                new Index.Builder(map(r)).index(getIndexFor(Relationship.class)).type(r.getType()).id(getKey(r)).build()
+        );
+    }
+
+    @Override
+    public <T extends PropertyContainer> String getIndexFor(Class<T> searchedType) {
+        return getIndexPrefix() + (searchedType.equals(Node.class) ? "-node" : "-relationship");
+    }
+}

--- a/src/main/java/com/graphaware/module/es/mapping/TransactionAwareMapping.java
+++ b/src/main/java/com/graphaware/module/es/mapping/TransactionAwareMapping.java
@@ -1,0 +1,9 @@
+package com.graphaware.module.es.mapping;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+
+public interface TransactionAwareMapping {
+
+    public void setGraphDatabaseService(GraphDatabaseService database);
+
+}

--- a/src/main/java/com/graphaware/module/es/mapping/json/DocumentMappingRepresentation.java
+++ b/src/main/java/com/graphaware/module/es/mapping/json/DocumentMappingRepresentation.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 package com.graphaware.module.es.mapping.json;
-
+// TODO[Ian]: backport into JSONParentMapping
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.graphaware.common.log.LoggerFactory;
@@ -23,8 +23,15 @@ import io.searchbox.client.JestResult;
 import io.searchbox.core.Delete;
 import io.searchbox.core.Index;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+
+import org.neo4j.cypher.internal.frontend.v2_3.ast.functions.Str;
+import org.neo4j.cypher.internal.frontend.v2_3.symbols.NodeType;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Result;
+import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.logging.Log;
 
 public class DocumentMappingRepresentation {
@@ -32,6 +39,13 @@ public class DocumentMappingRepresentation {
     private static final Log LOG = LoggerFactory.getLogger(DocumentMappingRepresentation.class);
     
     private DocumentMappingDefaults defaults;
+
+    private GraphDatabaseService database;
+
+    public void setGraphDatabaseService(GraphDatabaseService database) {this.database = database;};
+
+    @JsonProperty("parent_child_rels")
+    private HashMap<String, GraphChildDocumentMapper> parentChildRels;
 
     @JsonProperty("node_mappings")
     private List<GraphDocumentMapper> nodeMappers;
@@ -53,7 +67,7 @@ public class DocumentMappingRepresentation {
 
     public List<BulkableAction<? extends JestResult>> createOrUpdateNode(NodeExpressions node) {
         List<BulkableAction<? extends JestResult>> actions = new ArrayList<>();
-
+        // TODO [Ian]: Check if node is child - look in nodes mappers? or somewhere else....
         for (GraphDocumentMapper mapper : nodeMappers) {
             if (mapper.supports(node)) {
                 try {
@@ -70,9 +84,114 @@ public class DocumentMappingRepresentation {
         return actions;
     }
 
-    public List<BulkableAction<? extends JestResult>> createOrUpdateRelationship(RelationshipExpressions relationship) {
+    // TODO [Ian]: refactor - Can overload createOrUpdateNode + create+ update index
+    // TODO [Ian]: Optimize
+    public List<BulkableAction<? extends JestResult>> createOrUpdateChildNode(NodeExpressions node, GraphChildDocumentMapper child_maper) {
         List<BulkableAction<? extends JestResult>> actions = new ArrayList<>();
 
+        // TODO[Ian]: Store edge type in child document!
+
+//        String id = node.getId();
+//        getKeyProperty(node, defaults.getKeyProperty());
+
+        // If child is true
+        // Try statement
+
+        try {
+            // Get Id Here
+            // Get child_mapper = type
+            GraphDocumentMapper childNode = child_maper.getNode();
+
+            // TODO: I think this is the test we want to do to verify everything is supported
+//            childNode.supports(node); // This verifies the child / not the parent
+
+            // Just store the end result maybe?
+            DocumentRepresentation document = childNode.getDocumentRepresentation(node, defaults);
+
+            // TODO[Ian] optimize this! Only request the id
+            String docId = document.getId();
+            String keyProperty = defaults.getKeyProperty();
+
+            // /////////// Fetch parent ids//////////////////
+            // TODO[Ian]: put into its own function!
+            List<String> parentIds = new ArrayList<>();
+
+            // Maybe get labels here?
+            // TODO[Ian]: Try getType rather than get node - JK DON'T USE GET TYPE!!!!!!!!
+            // GET TYPE RETURNS THE USER DEFINED TYPE...NOT NODE LABEL -- add new node label field in config
+            // May look like its working if type is the same as label
+            String childLabel = childNode.getType();
+
+//            String childLabel = child_maper.getNodeType();
+            // TODO[Ian]: rename get parent to more descriptive name
+            String parentLabel = child_maper.getParent();
+
+            // TODO[Ian]: Put in own function and test
+            String query = "MATCH (n:" + parentLabel + ")" + child_maper.getRelated_by() + "(x:" + childLabel +
+                           ") where x." + keyProperty + "= \"" + docId + "\" return n." + keyProperty;
+
+            // Tentative plan - use cypher to find parents (easier than writing traversal)
+            Result results = this.database.execute(query);
+
+            Iterator<String> parent_ids = results.columnAs("n." + keyProperty);
+
+            // Loop through and get parent ids
+            while (parent_ids.hasNext()) {
+                String parentUUID = parent_ids.next();
+                parentIds.add(parentUUID);
+            }
+            ////////////////////////////////////
+            for (String parentUuid : parentIds ) {
+                String json = document.getJson();
+                actions.add(new Index.Builder(json).index(document.getIndex()).type(document.getType())
+                        .id(document.getId()).setParameter("parent", parentUuid).build());
+            }
+
+
+        } catch (Exception e) {
+            LOG.error("Error while creating or updating node", e);
+        }
+
+
+
+        return actions;
+    }
+
+    public List<BulkableAction<? extends JestResult>> createOrUpdateRelationship(RelationshipExpressions relationship) {
+        List<BulkableAction<? extends JestResult>> actions = new ArrayList<>();
+        // TODO: [IAN] add child check here (if there is a child relationship configured - executes child steps
+        // If the relationship is part of a parent node find the two attached sides to update children
+        if (parentChildRels.containsKey(relationship.getType())) {
+            GraphChildDocumentMapper childNodeMapper = parentChildRels.get(relationship.getType());
+
+            Node startNode;
+            Node endNode;
+            try ( Transaction tx = database.beginTx() )
+            {
+                startNode = this.database.getNodeById(relationship.getStartNodeGraphId());
+                endNode = this.database.getNodeById(relationship.getEndNodeGraphId());
+
+                NodeExpressions startNodeExpression = new NodeExpressions(startNode);
+                NodeExpressions endNodeExpression = new NodeExpressions(endNode);
+
+                // What do we do here about both ends (check root, check condition (ie that it is of type x - only send if that
+                startNodeExpression.getLabels();
+                endNodeExpression.getLabels();
+
+                // Add the actions to the queue here. If the childNodeMapper doesn't support node types createOrUpdateChildNode will ignore it
+                // TODO[Ian]: Should we check node types here?
+                actions.addAll(createOrUpdateChildNode(startNodeExpression, childNodeMapper));
+                actions.addAll(createOrUpdateChildNode(endNodeExpression, childNodeMapper));
+
+                tx.success();
+            } catch (Exception e) {
+                LOG.error("Error while creating relationship: " + relationship.toString(), e);
+            }
+
+        }
+
+        // Perform normal relationship checks here
+        // TODO: if relationshipMappers is empty errors out!
         for (GraphDocumentMapper mapping : relationshipMappers) {
             if (mapping.supports(relationship)) {
                 try {
@@ -105,6 +224,7 @@ public class DocumentMappingRepresentation {
         return actions;
     }
 
+    // TODO [Ian]: Why use this over the createOrUpdate functions
     public List<BulkableAction<? extends JestResult>> updateNodeAndRemoveOldIndices(NodeExpressions before, NodeExpressions after) {
         List<BulkableAction<? extends JestResult>> actions = new ArrayList<>();
         List<String> afterIndices = new ArrayList<>();

--- a/src/main/java/com/graphaware/module/es/mapping/json/GraphChildDocumentMapper.java
+++ b/src/main/java/com/graphaware/module/es/mapping/json/GraphChildDocumentMapper.java
@@ -1,0 +1,36 @@
+package com.graphaware.module.es.mapping.json;
+
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Wrap around a parent child relationship. Provides a container for holding child documents
+ */
+public class GraphChildDocumentMapper {
+//    @JsonProperty("node")
+    @JsonDeserialize(as=GraphDocumentMapper.class)
+    private GraphDocumentMapper node;
+
+    @JsonProperty
+    private String parent;
+
+    @JsonProperty
+    // Cypher query relating the two nodes
+    private String related_by;
+
+    @JsonProperty
+    private String nodeType;
+
+    public String getNodeType() { return nodeType; }
+
+    public String getParent() {
+        return parent;
+    }
+
+    public String getRelated_by() {
+        return related_by;
+    }
+
+    public GraphDocumentMapper getNode() { return node; }
+}

--- a/src/test/java/com/graphaware/module/es/mapping/ParentChildJsonFileMappingTest.java
+++ b/src/test/java/com/graphaware/module/es/mapping/ParentChildJsonFileMappingTest.java
@@ -1,0 +1,55 @@
+package com.graphaware.module.es.mapping;
+import com.graphaware.module.es.ElasticSearchConfiguration;
+import com.graphaware.module.es.util.ServiceLoader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class ParentChildJsonFileMappingTest extends JsonFileMapping{
+
+    protected static final String HOST = "localhost";
+    protected static final String PORT = "9201";
+
+//    protected GraphDatabaseService database;
+    protected ElasticSearchConfiguration configuration;
+
+    @Before
+    public void setUp() {
+
+    }
+
+    @After
+    public void tearDown() {
+
+    }
+
+    @Test
+    public void testMapping() {
+        Mapping mapping = ServiceLoader.loadMapping("com.graphaware.module.es.mapping.JsonFileMapping");
+        Map<String, String> mappingConfig = new HashMap<>();
+
+        // Lets decide what type of mapping we are going to do!
+        mappingConfig.put("file", "integration/mapping-basic-parent-child.json");
+
+        configuration = ElasticSearchConfiguration.defaultConfiguration()
+                .withMapping(mapping, mappingConfig)
+                .withUri(HOST)
+                .withPort(PORT);
+
+//        assertEquals("uuid", configuration.getMapping().getKeyProperty());
+//        assertEquals("default-index-node", ((JsonFileMapping)configuration.getMapping()).getMappingRepresentation().getDefaults().getDefaultNodesIndex());
+//        assertEquals("default-index-relationship", ((JsonFileMapping)configuration.getMapping()).getMappingRepresentation().getDefaults().getDefaultRelationshipsIndex());
+//        System.out.println((JsonFileMapping)configuration.getMapping());
+//        System.out.println("TEST!!");
+        // TODO[Ian]: write actual test here!
+    }
+
+}

--- a/src/test/resources/integration/mapping-basic-parent-child.json
+++ b/src/test/resources/integration/mapping-basic-parent-child.json
@@ -1,0 +1,34 @@
+{
+  "defaults": {
+    "key_property": "uuid",
+    "nodes_index": "default-index-node",
+    "relationships_index": "default-index-relationship",
+    "include_remaining_properties": true,
+    "blacklisted_node_properties": ["password", "uuid"]
+  },
+  "node_mappings": [
+    {
+      "condition": "hasLabel('Person')",
+      "type": "persons",
+      "properties": {
+        "name": "getProperty('firstName') + ' ' + getProperty('lastName')"
+      }
+    }
+  ],
+  "relationship_mappings": [
+    {
+      "condition": "isType('WORKS_FOR')",
+      "type": "workers"
+    }
+  ],
+  "parent_child_rels": {
+      "test": {
+        "node": {
+          "condition": "hasLabel('Person')",
+          "type": "Followers"
+        },
+        "parent": "Person",
+        "related_by": "-[test]-"
+      }
+  }
+}


### PR DESCRIPTION
This is pr is a work in progress. The goal is to get it tested and production ready then try to get it merged into the graphaware master copy (if they want it). It would be easier for everyone if we just contributed to a central source rather than maintain two copies. 

Also I can see this functionality being useful to more people than just us.

Things to note
* Elasticsearch index has to be pre-configured manually before neo4j run (to tell es that there is a parent child relationship)
* The node "type" has to be the same as the neo4j label - in the future we will add a specific neo4j label option
* Edge values are not stored in parent child relationships
* You cannot have more than one type between children nodes and regular nodes

* Code needs to be cleaned up.